### PR TITLE
Add `self_callouts` and requisite `db_helper.py` function, Update `README.md`, Patch Environment, Update Makefile for local testing

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -82,17 +82,18 @@ jobs:
             - name: add known hosts to runner
               run: |
                 ssh-keyscan -H ${{ secrets.SSH_SKYWATCH_HOST }} >> ~/.ssh/known_hosts
-
+                
+            # This is set to continue even w/ error, because there is a chance that docker compose down doesn't completely work
+            - name: remove old image from host
+              run: |
+                ssh ${{ secrets.HOST_USER }}@${{ secrets.SSH_SKYWATCH_HOST }} "cd /home/${{ secrets.HOST_USER }}/runner/raid-callouts && docker compose down"
+              continue-on-error: true
+              
             - name: clean build directory on host
               run: |
                 ssh ${{ secrets.HOST_USER }}@${{ secrets.SSH_SKYWATCH_HOST }} "rm -rdf /home/${{ secrets.HOST_USER }}/runner/raid-callouts"
               continue-on-error: true
             
-            # This is set to continue even w/ error, because there is a chance that docker compose down doesn't completely work
-            - name: remove old image from host
-              run: |
-                ssh ${{ secrets.HOST_USER }}@${{ secrets.SSH_SKYWATCH_HOST }} "cd /home/${{ secrets.HOST_USER }}/runner/ && docker compose down"
-              continue-on-error: true
                 
             - name: deploy /w rsync to host
               run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__/
 .vscode/
 patchnotes.md
 backups/*.tar
+dev-aux.Dockerfile
+dev-compose.yaml
+dev-core.Dockerfile

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,10 +7,4 @@ services:
   xiv-poster:
     build: 
       context: .
-      dockerfile: aux.Dockerfile    
-  # dnd-listener:
-  #   build: .
-  #   command: ["python", "src/py/bot-core.py", "dnd-database.ini", "dnd-discord.token"]
-  # dnd-poster:
-  #   build: .
-  #   command: ["python", "src/py/bot-aux.py", "dnd-database.ini", "dnd-discord.token", "477298331777761280", "927271992216920146"]
+      dockerfile: aux.Dockerfile   

--- a/core.Dockerfile
+++ b/core.Dockerfile
@@ -47,4 +47,4 @@ COPY . .
 # Expose the port that the application listens on.
 EXPOSE 8000
 
-CMD ["python3", "src/py/bot_core.py", "xiv-database.ini", "xiv-discord.token"]
+CMD ["python3", "src/py/bot_core.py", "xiv-database.ini", "xiv-discord.token", "865781604881530940", "888844785274724362"]

--- a/environment.yml
+++ b/environment.yml
@@ -45,5 +45,5 @@ dependencies:
       - pytest==8.2.2
       - requests>=2.32.4
       - setuptools>=78.1.1
-      - urllib3==2.3.0
+      - urllib3==2.5.0
       - yarl==1.18.3

--- a/makefile
+++ b/makefile
@@ -6,6 +6,9 @@ db_tests_path = src/py/db_helper_tests.py
 compose_up:
 	docker compose up --build
 
+compose_up_dev:
+	docker compose --file "dev-compose.yaml" up --build 
+
 clean:
 	docker compose down
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ pytest==8.2.2
 requests>=2.32.4
 setuptools>=78.1.1
 tomlkit==0.13.2
-urllib3==2.3.0
+urllib3==2.5.0
 wheel==0.41.2
 yarl==1.18.3

--- a/src/py/bot_core.py
+++ b/src/py/bot_core.py
@@ -238,7 +238,7 @@ async def remove_callout(interaction: discord.Interaction, date_of_callout: str)
 async def schedule(interaction: discord.Interaction, days: int = DAYS_FOR_CALLOUTS) -> None:
     delete_invalidate()
     cleanup_invalidate()
-    interaction.response.defer(thinking=True)
+    await interaction.response.defer(thinking=True)
     callouts: list = DATABASE_CONN.query_callouts(days=days)
     callouts: str = DATABASE_CONN.formatted_list_of_callouts(callouts)
     await interaction.followup.send(f'Callouts for the next {days} days:\n{callouts}')

--- a/src/py/bot_core.py
+++ b/src/py/bot_core.py
@@ -62,6 +62,16 @@ async def on_ready() -> None:
     print(f'{client.user} has connected to Discord!')
     return
 
+@client.event
+async def on_error(interaction: discord.Interaction) -> None:
+    delete_invalidate()
+    cleanup_invalidate()
+    output = "Something awful has happened. In all honesty you should never see this message. Reporting to <@{CONTRASTELLAR}>."
+    await interaction.response.send_message(output)
+    return
+
+
+
 
 @client.tree.command(name="help")
 async def bot_help(interaction: discord.Interaction) -> None:
@@ -146,7 +156,7 @@ async def ping(interaction: discord.Interaction) -> None:
     delete_invalidate()
     cleanup_invalidate()
     user_id = interaction.user.id
-    await interaction.response.send_message(f'Pong! {user_id}')
+    await interaction.response.send_message(f'Pong! {user_id} -- the bot is active, please message contrastellar with issues!')
     return
 
 

--- a/src/py/bot_core.py
+++ b/src/py/bot_core.py
@@ -44,6 +44,8 @@ parser: argparse.ArgumentParser = argparse.ArgumentParser(prog='callouts core',
                         description='The listener for the callouts bot functionality')
 parser.add_argument('database')
 parser.add_argument('token')
+parser.add_argument('guild_id', type=int)
+parser.add_argument('channel_id', type=int)
 
 
 # utility methods
@@ -60,6 +62,11 @@ def delete_invalidate() -> None:
 async def on_ready() -> None:
     await client.tree.sync()
     print(f'{client.user} has connected to Discord!')
+    print(args.guild_id)
+    guild: discord.Guild = client.get_guild(args.guild_id)
+    channel: discord.TextChannel = guild.get_channel(args.channel_id)
+    output = f'The bot is now running!\nPlease message <@{CONTRASTELLAR}> with any errors!'
+    await channel.send(output)
     return
 
 @client.event

--- a/src/py/db_helper_tests.py
+++ b/src/py/db_helper_tests.py
@@ -28,6 +28,9 @@ class TestClass():
         callout = self.DATABASE_CONN.add_callout(user_id=1, callout=datetime.date.today(), reason='test', nickname='test', char_name='test', potential_fill='test')
         assert callout is None
 
+    def test_self_query_callouts(self) -> None:
+        self_callouts = self.DATABASE_CONN.query_self_callouts(user_id=1, days=365)
+        assert self_callouts is not None
 
     def test_callouts(self) -> None:
         callout = self.DATABASE_CONN.query_callouts(days=7)

--- a/src/py/helper/db_helper.py
+++ b/src/py/helper/db_helper.py
@@ -99,6 +99,15 @@ class DBHelper():
         self.__CONN.commit()
 
         return cursor.fetchall()
+    
+    def query_self_callouts(self, user_id: int, days: int = 365):
+        self.__CONN = connect_config(self._config)
+        self.__CONN.autocommit = True
+        cursor = self.__CONN.cursor()
+        cursor.execute(f"SELECT * FROM newcallouts WHERE date >= NOW() - INTERVAL '1 day' AND date <= NOW() + INTERVAL '{days} days' AND user_id = {user_id} ORDER BY date ASC;")
+        self.__CONN.commit()
+
+        return cursor.fetchall()
 
 
     def add_callout(self, user_id: int, callout: datetime.date, reason: str, nickname: str, char_name: str, potential_fill: str) -> None:


### PR DESCRIPTION
1. Had an idea a few weeks ago about making a command that lets users see only their own callouts, this is that implementation
1.a. There are updates to the code for both the bot_core and the database interface.
2. This PR includes updates to the README.md as well
3. Environment had security issues, this PR addresses that.
4. I needed to accommodate local testing. Will address the local (Phenex) Test/Dev environments currently interfacing /w the Prod Database in a future PR
4.a. This means that a local instance of the bot can be run in a non-Prod Discord Bot, but it still interfaces with the Prod Database
4.b. Documentation regarding setting up a local Test/Dev environment will be addressed in a future PR

No other major updates to functionality are in this PR.
Does not address #20 